### PR TITLE
Fix problem with CDN server

### DIFF
--- a/mathjax.cdn.tid
+++ b/mathjax.cdn.tid
@@ -12,12 +12,13 @@ tags: $:/tags/RawMarkup $:/core/wiki/rawmarkup
     tex2jax: {
       inlineMath: [
         ['$','$'],
-        ['\\\\(','\\\\)']
+        ['\\(','\\)']
       ],
       processEscapes: true
    },
    TeX: {
-      extensions: ["AMSsymbols.js","AMSmath.js"]
+      extensions: ["AMSsymbols.js","AMSmath.js"],
+      equationNumbers: { autoNumber: "AMS" }
    }
   });
 })();

--- a/mathjax.cdn.tid
+++ b/mathjax.cdn.tid
@@ -22,4 +22,4 @@ tags: $:/tags/RawMarkup $:/core/wiki/rawmarkup
   });
 })();
 </script>
-<script src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>


### PR DESCRIPTION
as announced in https://www.mathjax.org/changes-to-the-mathjax-cdn/, the
Rackspace address was retired on July 31, 2014. Instead, it should be
used the address https://cdn.mathjax.org/...
